### PR TITLE
Ensure that previous session is cleared before loading login page on Target.com

### DIFF
--- a/src/sites/target.ts
+++ b/src/sites/target.ts
@@ -85,11 +85,11 @@ async function clipCoupons(singletons: Singletons): Promise<number> {
 async function login(singletons: Singletons, account: Account) {
   const { page, logger } = singletons;
   const { email, password } = account;
+  await clearSessionStorage(page);
   await page.goto(loginUrl, {
     timeout: 15 * 1000,
     waitUntil: ['domcontentloaded', 'networkidle2'],
   });
-  await clearSessionStorage(page);
   await logger.screenshot(page);
   await page.waitForSelector('input[name=password]');
 


### PR DESCRIPTION
I was having issues with repeated runs because when loading `https://www.target.com/account` the previous login session was still stored & my account dashboard loaded instead of the login page. After 30 seconds of waiting, the program would fail due to the login button never appearing. Moving the `clearSessionStorage` call to before loading the account page fixed this issue for me.

Thanks for your work on this, I'm sure this'll find me some savings in the near future.